### PR TITLE
lis2duxs12_reg.c(h): Fix struct and enum names

### DIFF
--- a/lis2duxs12_reg.c
+++ b/lis2duxs12_reg.c
@@ -1753,19 +1753,19 @@ int32_t lis2duxs12_fifo_mode_get(stmdev_ctx_t *ctx, lis2duxs12_fifo_mode_t *val)
       val->operation = LIS2DUXS12_FIFO_OFF;
     }
     else {
-      val->operation = (enum operation)fifo_ctrl.fifo_mode;
+      val->operation = (enum lis2duxs12_operation)fifo_ctrl.fifo_mode;
     }
     val->cfg_change_in_fifo = fifo_ctrl.cfg_chg_en;
 
     /* get fifo depth (1X/2X) */
-    val->store = (enum store)fifo_ctrl.fifo_depth;
+    val->store = (enum lis2duxs12_store)fifo_ctrl.fifo_depth;
 
     /* Get xl_only_fifo */
     val->xl_only = fifo_wtm.xl_only_fifo;
 
     /* get batching info */
-    val->batch.dec_ts = (enum dec_ts)fifo_batch.dec_ts_batch;
-    val->batch.bdr_xl = (enum bdr_xl)fifo_batch.bdr_xl;
+    val->batch.dec_ts = (enum lis2duxs12_dec_ts)fifo_batch.dec_ts_batch;
+    val->batch.bdr_xl = (enum lis2duxs12_bdr_xl)fifo_batch.bdr_xl;
 
     /* get watermark */
     val->watermark = fifo_wtm.fth;
@@ -2564,7 +2564,7 @@ int32_t lis2duxs12_sixd_config_get(stmdev_ctx_t *ctx, lis2duxs12_sixd_config_t *
 
   ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_SIXD, (uint8_t *)&sixd, 1);
 
-  val->mode = (enum mode)sixd.d4d_en;
+  val->mode = (enum lis2duxs12_mode)sixd.d4d_en;
 
   switch ((sixd.d6d_ths))
   {
@@ -2712,8 +2712,8 @@ int32_t lis2duxs12_wakeup_config_get(stmdev_ctx_t *ctx, lis2duxs12_wakeup_config
 
     val->wake_ths_weight = int_cfg.wake_ths_w;
     val->wake_ths = wup_ths.wk_ths;
-    val->wake_enable = (enum wake_enable)wup_ths.sleep_on;
-    val->inact_odr = (enum inact_odr)ctrl4.inact_odr;
+    val->wake_enable = (enum lis2duxs12_wake_enable)wup_ths.sleep_on;
+    val->inact_odr = (enum lis2duxs12_inact_odr)ctrl4.inact_odr;
   }
 
   return ret;
@@ -2795,7 +2795,7 @@ int32_t lis2duxs12_tap_config_get(stmdev_ctx_t *ctx, lis2duxs12_tap_config_t *va
 
   if (ret == 0)
   {
-    val->axis = (enum axis)tap_cfg0.axis;
+    val->axis = (enum lis2duxs12_axis)tap_cfg0.axis;
     val->inverted_peak_time = tap_cfg0.invert_t;
     val->pre_still_ths = tap_cfg1.pre_still_ths;
     val->post_still_ths = tap_cfg3.post_still_ths;

--- a/lis2duxs12_reg.h
+++ b/lis2duxs12_reg.h
@@ -2298,7 +2298,7 @@ int32_t lis2duxs12_emb_pin_int2_route_get(stmdev_ctx_t *ctx,
                                           lis2duxs12_emb_pin_int_route_t *val);
 
 typedef struct {
-  enum int_cfg
+  enum lis2duxs12_int_cfg
   {
     LIS2DUXS12_INT_DISABLED             = 0x0,
     LIS2DUXS12_INT_LEVEL                = 0x1,
@@ -2319,7 +2319,7 @@ int32_t lis2duxs12_embedded_int_config_set(stmdev_ctx_t *ctx, lis2duxs12_embedde
 int32_t lis2duxs12_embedded_int_config_get(stmdev_ctx_t *ctx, lis2duxs12_embedded_int_config_t *val);
 
 typedef struct {
-  enum operation
+  enum lis2duxs12_operation
   {
     LIS2DUXS12_BYPASS_MODE              = 0x0,
     LIS2DUXS12_FIFO_MODE                = 0x1,
@@ -2329,7 +2329,7 @@ typedef struct {
     LIS2DUXS12_BYPASS_TO_FIFO_MODE      = 0x7,
     LIS2DUXS12_FIFO_OFF                 = 0x8,
   } operation;
-  enum store {
+  enum lis2duxs12_store {
     LIS2DUXS12_FIFO_1X                  = 0,
     LIS2DUXS12_FIFO_2X                  = 1,
   } store;
@@ -2337,14 +2337,14 @@ typedef struct {
   uint8_t watermark                    : 7; /* (0 disable) max 127 @16bit, even and max 256 @8bit.*/
   uint8_t cfg_change_in_fifo           : 1;
   struct {
-    enum dec_ts
+    enum lis2duxs12_dec_ts
     {
       LIS2DUXS12_DEC_TS_OFF             = 0x0,
       LIS2DUXS12_DEC_TS_1               = 0x1,
       LIS2DUXS12_DEC_TS_8               = 0x2,
       LIS2DUXS12_DEC_TS_32              = 0x3,
     } dec_ts; /* decimation for timestamp batching*/
-    enum bdr_xl
+    enum lis2duxs12_bdr_xl
     {
       LIS2DUXS12_BDR_XL_ODR             = 0x0,
       LIS2DUXS12_BDR_XL_ODR_DIV_2       = 0x1,
@@ -2393,11 +2393,11 @@ typedef struct {
     float_t deg_c;
     int16_t raw;
   }heat;
-  struct pedo {
+  struct lis2duxs12_pedo {
     uint32_t steps;
     uint32_t timestamp;
   } pedo;
-  struct cfg_chg {
+  struct lis2duxs12_cfg_chg {
     uint8_t cfg_change                 : 1; /* 1 if ODR/BDR configuration is changed */
     uint8_t odr                        : 4; /* ODR */
     uint8_t bw                         : 2; /* BW */
@@ -2482,14 +2482,14 @@ int32_t lis2duxs12_ff_thresholds_set(stmdev_ctx_t *ctx, lis2duxs12_ff_thresholds
 int32_t lis2duxs12_ff_thresholds_get(stmdev_ctx_t *ctx, lis2duxs12_ff_thresholds_t *val);
 
 typedef struct {
-  enum threshold
+  enum lis2duxs12_threshold
   {
     LIS2DUXS12_DEG_80 = 0x0,
     LIS2DUXS12_DEG_70 = 0x1,
     LIS2DUXS12_DEG_60 = 0x2,
     LIS2DUXS12_DEG_50 = 0x3,
   } threshold;
-  enum mode
+  enum lis2duxs12_mode
   {
     LIS2DUXS12_6D = 0x0,
     LIS2DUXS12_4D = 0x1,
@@ -2500,7 +2500,7 @@ int32_t lis2duxs12_sixd_config_set(stmdev_ctx_t *ctx, lis2duxs12_sixd_config_t v
 int32_t lis2duxs12_sixd_config_get(stmdev_ctx_t *ctx, lis2duxs12_sixd_config_t *val);
 
 typedef struct {
-  enum wake_dur
+  enum lis2duxs12_wake_dur
   {
     LIS2DUXS12_0_ODR  = 0x000, /* 0 ODR time */
     LIS2DUXS12_1_ODR  = 0x001, /* 1 ODR time */
@@ -2513,12 +2513,12 @@ typedef struct {
   uint8_t sleep_dur                    : 4;       /* 1 LSB == 512 ODR time */
   uint8_t wake_ths                     : 7;       /* wakeup threshold */
   uint8_t wake_ths_weight              : 1;       /* 0: 1LSB = FS_XL/2^6, 1: 1LSB = FS_XL/2^8 */
-  enum wake_enable
+  enum lis2duxs12_wake_enable
   {
     LIS2DUXS12_SLEEP_OFF = 0,
     LIS2DUXS12_SLEEP_ON  = 1,
   } wake_enable;
-  enum inact_odr
+  enum lis2duxs12_inact_odr
   {
     LIS2DUXS12_ODR_NO_CHANGE       = 0,  /* no odr change during inactivity state */
     LIS2DUXS12_ODR_1_6_HZ          = 1,  /* set odr to 1.6Hz during inactivity state */
@@ -2531,7 +2531,7 @@ int32_t lis2duxs12_wakeup_config_set(stmdev_ctx_t *ctx, lis2duxs12_wakeup_config
 int32_t lis2duxs12_wakeup_config_get(stmdev_ctx_t *ctx, lis2duxs12_wakeup_config_t *val);
 
 typedef struct {
-  enum axis
+  enum lis2duxs12_axis
   {
     LIS2DUXS12_TAP_NONE  = 0x0, /* No axis */
     LIS2DUXS12_TAP_ON_X  = 0x1, /* Detect tap on X axis */


### PR DESCRIPTION
Names of some of the enums and structs changed to avoid type names collision when used along with LIS2DUX12 sensors in the same project